### PR TITLE
Update route53-cluster-zone to 0.3.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ locals {
 
 # Kops domain (e.g. `kops.domain.com`)
 module "domain" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.2.5"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.3.1"
   namespace        = "${var.namespace}"
   name             = "${var.cluster_name}"
   stage            = "${var.stage}"


### PR DESCRIPTION
## Why?

Version 0.3.1 adds `allow_overwrite = true`, which is needed to update the SOA record.