### PR TITLE
Update terraform-aws-route53-cluster-zone to 0.3.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ locals {
 
 # Kops domain (e.g. `kops.domain.com`)
 module "domain" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.2.5"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.3.1"
   namespace        = "${var.namespace}"
   name             = "${var.cluster_name}"
   stage            = "${var.stage}"


### PR DESCRIPTION
## what
Update terraform-aws-route53-cluster-zone to 0.3.1

## why
Required by changes to Terraform AWS provider in order to be able to create a DNS domain