### PR TITLE
Allow use of existing S3 bucket in other region

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Usage
 
+
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-kops-state-backend/releases).
+
+
 This example will create a DNS zone called `us-east-1.cloudxl.net` and delegate it from the parent zone `cloudxl.net` by setting `NS` and `SOA` records in the parent zone.
 
 It will also create an S3 bucket with the name `cp-prod-kops-state` for storing `kops` state.
@@ -133,6 +138,7 @@ Available targets:
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | block_public_access_enabled | Block all public access from bucket level | string | `true` | no |
 | cluster_name | Kops cluster name (e.g. `us-east-1` or `cluster-1`) | string | `us-east-1` | no |
+| create_bucket | Set to `false` to use existing S3 bucket for kops state store instead of creating one. | string | `true` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes` | string | `-` | no |
 | domain_enabled | A boolean that determines whether a DNS Zone for the kops domain is created | string | `true` | no |
 | force_destroy | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without errors. These objects are not recoverable | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,6 +6,7 @@
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | block_public_access_enabled | Block all public access from bucket level | string | `true` | no |
 | cluster_name | Kops cluster name (e.g. `us-east-1` or `cluster-1`) | string | `us-east-1` | no |
+| create_bucket | Set to `false` to use existing S3 bucket for kops state store instead of creating one. | string | `true` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes` | string | `-` | no |
 | domain_enabled | A boolean that determines whether a DNS Zone for the kops domain is created | string | `true` | no |
 | force_destroy | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without errors. These objects are not recoverable | string | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   version = "~> 2.17"
 
-  alias = "s3"
+  alias  = "s3"
   region = "${var.region}"
 }
 
@@ -57,14 +57,14 @@ module "s3_label" {
 data "aws_s3_bucket" "default" {
   provider = "aws.s3"
 
-  count = "${local.create_s3_bucket ? 0 : 1}"
+  count  = "${local.create_s3_bucket ? 0 : 1}"
   bucket = "${module.s3_label.id}"
 }
 
 resource "aws_s3_bucket" "default" {
   provider = "aws.s3"
 
-  count = "${local.create_s3_bucket ? 1 : 0}"
+  count         = "${local.create_s3_bucket ? 1 : 0}"
   bucket        = "${module.s3_label.id}"
   acl           = "${var.acl}"
   region        = "${var.region}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,26 +19,26 @@ output "zone_name" {
 }
 
 output "bucket_name" {
-  value       = "${aws_s3_bucket.default.bucket}"
+  value       = "${coalesce(join("",aws_s3_bucket.default.*.bucket),join("",data.aws_s3_bucket.default.*.bucket))}"
   description = "S3 bucket name"
 }
 
 output "bucket_region" {
-  value       = "${aws_s3_bucket.default.region}"
+  value       = "${coalesce(join("",aws_s3_bucket.default.*.region),join("",data.aws_s3_bucket.default.*.region))}"
   description = "S3 bucket region"
 }
 
 output "bucket_domain_name" {
-  value       = "${aws_s3_bucket.default.bucket_domain_name}"
+  value       = "${coalesce(join("",aws_s3_bucket.default.*.bucket_domain_name),join("",data.aws_s3_bucket.default.*.bucket_domain_name))}"
   description = "S3 bucket domain name"
 }
 
 output "bucket_id" {
-  value       = "${aws_s3_bucket.default.id}"
+  value       = "${coalesce(join("",aws_s3_bucket.default.*.id),join("",data.aws_s3_bucket.default.*.id))}"
   description = "S3 bucket ID"
 }
 
 output "bucket_arn" {
-  value       = "${aws_s3_bucket.default.arn}"
+  value       = "${coalesce(join("",aws_s3_bucket.default.*.arn),join("",data.aws_s3_bucket.default.*.arn))}"
   description = "S3 bucket ARN"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -87,7 +87,7 @@ variable "domain_enabled" {
 }
 
 variable "create_bucket" {
-  type = "string"
-  default = "true"
+  type        = "string"
+  default     = "true"
   description = "Set to `false` to use existing S3 bucket for kops state store instead of creating one."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,9 @@ variable "domain_enabled" {
   default     = "true"
   description = "A boolean that determines whether a DNS Zone for the kops domain is created"
 }
+
+variable "create_bucket" {
+  type = "string"
+  default = "true"
+  description = "Set to `false` to use existing S3 bucket for kops state store instead of creating one."
+}


### PR DESCRIPTION
## what
Allow use of existing S3 bucket in a different region for the `kops` state store

## why
Multi-region `kops` clusters share a single S3 bucket